### PR TITLE
[29기 박겸영] 메인 페이지: 캐러셀 구현

### DIFF
--- a/src/pages/Main/Carousel/Carousel.js
+++ b/src/pages/Main/Carousel/Carousel.js
@@ -1,29 +1,70 @@
-import React from 'react';
+import React, { useState } from 'react';
 import CarouselItem from './CarouselItem/CarouselItem';
 import './Carousel.scss';
 
-const Carousel = ({ dataList }) => {
+const Carousel = ({ className, dataList }) => {
+  const [slideIndex, setSlideIndex] = useState(0);
+  const onClick = event => {
+    if (event.target.className.includes('prev')) {
+      setSlideIndex(curr => --curr);
+    }
+    if (event.target.className.includes('next')) {
+      setSlideIndex(curr => ++curr);
+    }
+  };
+  const firstSlide =
+    slideIndex === 0
+      ? {
+          style: { transform: 'translateX(-80px)' },
+        }
+      : null;
+  const lastSlide =
+    slideIndex === dataList.length - 3
+      ? {
+          style: { transform: 'translateX(80px)' },
+        }
+      : null;
   return (
-    <div className="Carousel">
-      <div className="container">
-        <button>
-          <i className="fas fa-chevron-left" />
-        </button>
-        <div className="contentWrapper">
-          {dataList &&
-            dataList.map(data => (
-              <CarouselItem
-                key={data.idx}
-                heading={data.heading}
-                description={data.description}
-                alt={data.alt}
-                src={data.src}
-              />
-            ))}
-        </div>
-        <button>
-          <i className="fas fa-chevron-right" />
-        </button>
+    <div className={`Carousel ${className}`}>
+      <button
+        className="navigation prev"
+        onClick={onClick}
+        style={firstSlide && firstSlide.style}
+        disabled={firstSlide}
+      >
+        <i className="fas fa-chevron-left prev" />
+      </button>
+      <div
+        className="itemWrapper"
+        style={{ transform: `translateX(calc(-100% / 3 * ${slideIndex}))` }}
+      >
+        {dataList &&
+          dataList.map(data => (
+            <CarouselItem
+              key={data.id}
+              heading={data.heading}
+              description={data.description}
+              alt={data.alt}
+              src={data.src}
+            />
+          ))}
+      </div>
+      <button
+        className="navigation next"
+        onClick={onClick}
+        style={lastSlide && lastSlide.style}
+        disabled={lastSlide}
+      >
+        <i className="fas fa-chevron-right next" />
+      </button>
+      <div className="pagination">
+        <div
+          className="current"
+          style={{
+            width: `calc(100% / ${dataList.length - 2})`,
+            transform: `translateX(calc(100% * ${slideIndex}))`,
+          }}
+        />
       </div>
     </div>
   );

--- a/src/pages/Main/Carousel/Carousel.js
+++ b/src/pages/Main/Carousel/Carousel.js
@@ -4,26 +4,32 @@ import './Carousel.scss';
 
 const Carousel = ({ className, dataList }) => {
   const [slideIndex, setSlideIndex] = useState(0);
+
   const onClick = event => {
-    if (event.target.className.includes('prev')) {
+    const isPrev = event.target.className.includes('prev');
+    const isNext = event.target.className.includes('next');
+    if (isPrev) {
       setSlideIndex(curr => --curr);
     }
-    if (event.target.className.includes('next')) {
+    if (isNext) {
       setSlideIndex(curr => ++curr);
     }
   };
+
   const firstSlide =
     slideIndex === 0
       ? {
           style: { transform: 'translateX(-80px)' },
         }
       : null;
+
   const lastSlide =
     slideIndex === dataList.length - 3
       ? {
           style: { transform: 'translateX(80px)' },
         }
       : null;
+
   return (
     <div className={`Carousel ${className}`}>
       <button

--- a/src/pages/Main/Carousel/Carousel.scss
+++ b/src/pages/Main/Carousel/Carousel.scss
@@ -1,9 +1,54 @@
 @import '../../../styles/variables.scss';
 
 .Carousel {
-  .contentWrapper {
-    overflow: hidden;
+  position: relative;
+  padding: 150px 0;
+  overflow: hidden;
+
+  button.navigation {
+    position: absolute;
+    top: calc(50% - 80px);
+    width: 80px;
+    height: 80px;
+    background-color: $darkgray;
+    color: $ivory;
+    text-align: center;
+    font-size: 16px;
+    z-index: 1;
+    transition: transform cubic-bezier(0.22, 0.61, 0.36, 1) 0.5s;
+
+    &.prev {
+      left: 0;
+      transform: translateX(-80px);
+    }
+
+    &.next {
+      right: 0;
+      transform: translateX(80px);
+    }
+  }
+
+  &:hover {
+    button.navigation {
+      transform: translateX(0);
+    }
+  }
+
+  .itemWrapper {
     display: flex;
     margin: 0 80px 48px;
+    transition: transform ease 0.5s;
+  }
+
+  .pagination {
+    height: 2px;
+    margin: 0 80px 40px;
+    background-color: rgba(0, 0, 0, 0.2);
+
+    .current {
+      height: 100%;
+      background-color: $darkgray;
+      transition: transform cubic-bezier(0.22, 0.61, 0.36, 1) 0.5s;
+    }
   }
 }

--- a/src/pages/Main/Carousel/CarouselItem/CarouselItem.scss
+++ b/src/pages/Main/Carousel/CarouselItem/CarouselItem.scss
@@ -13,15 +13,19 @@
 
     img {
       width: 100%;
+      height: 100%;
       object-fit: contain;
     }
   }
 
   .textWrapper {
     padding: 0 20px;
+    line-height: 1.33;
+    letter-spacing: -0.2px;
 
     h5 {
-      margin: 10px;
+      margin: 10px 0;
+      line-height: 1.7;
     }
   }
 }

--- a/src/pages/Main/Home/Home.scss
+++ b/src/pages/Main/Home/Home.scss
@@ -20,8 +20,9 @@
   }
 
   .logo {
-    width: 168px;
-    margin: 85px 0 0 24px;
+    width: $logo-width;
+    margin-top: 85px;
+    margin-left: $logo-left;
 
     img {
       width: 100%;

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -9,10 +9,10 @@ const Main = () => {
   return (
     <>
       <Home />
-      <Carousel dataList={FACIAL_PRODUCTS} />
+      <Carousel className="facial" dataList={FACIAL_PRODUCTS} />
       {PROMOTIONS.map(promotion => (
         <TwoColumnsPromotion
-          key={promotion.idx}
+          key={promotion.id}
           isTextOnLeft={promotion.isTextOnLeft}
           isContentImg={promotion.isContentImg}
           subTitle={promotion.subTitle}
@@ -24,7 +24,7 @@ const Main = () => {
           src={promotion.src}
         />
       ))}
-      <Carousel dataList={BODY_PRODUCTS} />
+      <Carousel className="body" dataList={BODY_PRODUCTS} />
       <TwoColumnsPromotion
         isTextOnLeft={true}
         isContentImg={false}

--- a/src/pages/Main/Main.scss
+++ b/src/pages/Main/Main.scss
@@ -1,1 +1,7 @@
 @import '../../styles/variables.scss';
+
+.Carousel {
+  &.body {
+    padding-top: 50px;
+  }
+}

--- a/src/pages/Main/mainData.js
+++ b/src/pages/Main/mainData.js
@@ -98,6 +98,13 @@ export const BODY_PRODUCTS = [
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
+    src: 'https://images.unsplash.com/photo-1628088305628-a0aba9b069a1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
+  },
+  {
+    id: 5,
+    heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
+    description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
+    alt: 'product',
     src: 'https://images.unsplash.com/photo-1628088306756-ef21fbec7386?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
   },
 ];

--- a/src/pages/Main/mainData.js
+++ b/src/pages/Main/mainData.js
@@ -1,6 +1,6 @@
 export const PROMOTIONS = [
   {
-    idx: 0,
+    id: 0,
     isTextOnLeft: true,
     isContentImg: true,
     subTitle: '실험실에서 배운 교훈',
@@ -13,7 +13,7 @@ export const PROMOTIONS = [
     src: '/images/main/main-2.jpg',
   },
   {
-    idx: 1,
+    id: 1,
     isTextOnLeft: false,
     isContentImg: true,
     heading: '놀라움과 즐거움을 전하는 기프트',
@@ -28,76 +28,76 @@ export const PROMOTIONS = [
 
 export const FACIAL_PRODUCTS = [
   {
-    idx: 0,
+    id: 0,
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
-    src: 'https://images.unsplash.com/photo-1628088306391-1631cdd36e7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
+    src: 'https://images.unsplash.com/photo-1573575154488-f88a60e170df?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80',
   },
   {
-    idx: 1,
+    id: 1,
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
-    src: 'https://images.unsplash.com/photo-1628088306391-1631cdd36e7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
+    src: 'https://images.unsplash.com/photo-1620916566398-39f1143ab7be?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80',
   },
   {
-    idx: 2,
+    id: 2,
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
-    src: 'https://images.unsplash.com/photo-1628088306391-1631cdd36e7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
+    src: 'https://images.unsplash.com/photo-1620917670397-dc7bc45eeda8?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80',
   },
   {
-    idx: 3,
+    id: 3,
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
-    src: 'https://images.unsplash.com/photo-1628088306391-1631cdd36e7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
+    src: 'https://images.unsplash.com/photo-1618330834871-dd22c2c226ca?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80',
   },
   {
-    idx: 4,
+    id: 4,
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
-    src: 'https://images.unsplash.com/photo-1628088306391-1631cdd36e7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
+    src: 'https://images.unsplash.com/photo-1608571424266-edeb9bbefdec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80',
   },
 ];
 
 export const BODY_PRODUCTS = [
   {
-    idx: 0,
+    id: 0,
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
     src: 'https://images.unsplash.com/photo-1628088306391-1631cdd36e7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
   },
   {
-    idx: 1,
+    id: 1,
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
-    src: 'https://images.unsplash.com/photo-1628088306391-1631cdd36e7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
+    src: 'https://images.unsplash.com/photo-1628088306622-771bd1f8a63d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
   },
   {
-    idx: 2,
+    id: 2,
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
-    src: 'https://images.unsplash.com/photo-1628088306391-1631cdd36e7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
+    src: 'https://images.unsplash.com/photo-1628088304607-d45a3543ca5f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
   },
   {
-    idx: 3,
+    id: 3,
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
-    src: 'https://images.unsplash.com/photo-1628088306391-1631cdd36e7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
+    src: 'https://images.unsplash.com/photo-1628088304567-75d31f8ecaaf?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
   },
   {
-    idx: 4,
+    id: 4,
     heading: '파슬리 씨드 안티 옥시던트 페이셜 트리트먼트',
     description: '집중적인 보습으로 피부를 탄탄하게 강화시킵니다.',
     alt: 'product',
-    src: 'https://images.unsplash.com/photo-1628088306391-1631cdd36e7c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
+    src: 'https://images.unsplash.com/photo-1628088306756-ef21fbec7386?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=580&q=80',
   },
 ];


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 캐러셀 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. `<Carousel>` 컴포넌트 구현
- navigation 버튼(prev, next) 구현
  - 첫 슬라이드, 마지막 슬라이드에서 이전/다음 슬라이드로 넘어가는 것을 방지하기 위해 버튼을 `transform`으로 숨기고 `disabled` 속성을 주어 비활성화함.
- pagination bar 구현
- 현재 슬라이드의 index를 state로 관리하여 state에 따라 아이템을 감싸는 wrapper 태그와 pagination bar의 `transform: translateX()` 값이 달라지도록 함. 데이터 배열의 length를 변수로 사용하여 데이터 배열의 길이가 달라져도 유동적으로 적용됨.
- 컴포넌트 재사용성을 높이기 위해 한 슬라이드에 들어가는 아이템 개수도 변수화하고 props로 넘겨줄 예정임.
- **상품 상세페이지에도 캐러셀이 들어가기 때문에 상세페이지에서도 재사용될 수 있도록 수정한 후에 공용 폴더인 `components/`로 파일을 이동할 예정임.**
- 이후 반응형을 적용하게 된다면 navigation 버튼의 width도 변수화해야 함.
2.  `<Carousel>` 컴포넌트를 메인 페이지에 사용
- `mainData.js`에서 mock data를 불러와 캐러셀마다 각각 다른 상품을 보여줌. 이후 백엔드에서 데이터를 불러와 사용할 예정임.


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 처음에는 navigaion 버튼을 클릭했을 때 클래스명이 prev라면 왼쪽으로, 아니면 오른쪽으로 이동하는 로직을 구현했었는데, 종종 반대 방향으로 이동하는 문제점이 발생했습니다. 원인을 정확하게 파악하지는 못했지만 조건이 불분명하기 때문일 것이라 생각하여 prev, next 모두 조건에 포함하니 문제가 해결되었습니다.
- navigation 버튼 안에 아이콘을 `<i>` 태그로 넣었는데, 아이콘 부분을 클릭하면 슬라이드가 이동하지 않는 문제점이 발견되었습니다. 원인은 버튼의 클래스명(prev, next)을 기준으로 함수를 적용했는데 `<i>` 태그에는 해당 클래스명이 없어서 함수가 작동하지 않기 때문이었습니다. `<i>` 태그에도 같은 클래스명(prev, next)을 부여하니 해결되었습니다.
- pagination bar를 이동시킬 때 `position: absolute`를 주고 `left`로 이동시키는 방법과 `transform` 속성으로 이동시키는 방법이 있습니다. `left`의 경우 부모 요소를 기준으로 이동거리를 계산해야 하기 때문에 데이터 배열의 길이를 이용해 계산해야 하는 반면, `transform`은 자기 자신을 기준으로 계산하므로 한 번에 100%씩 이동시키면 되기 때문에 `transform`이 더 간단하다고 판단했습니다.
- 흔히 슬라이더라고 부르는 UI의 정확한 명칭이 캐러셀이라는 점을 알게 되었고 라이브러리 없이 구현할 수 있을까 생각했는데 직접 구현하게 되어 뿌듯합니다 ☺

<br />

## :: 기타 질문 및 특이 사항
- state 등 react에서 사용하는 변수를 sass에서 적용하고 싶은데, sass에서 react의 변수를 불러오는 방법을 찾지 못했습니다. 인라인 스타일은 지양하라고 배웠는데 변수를 스타일에 그대로 가져다 쓰려면 인라인 스타일 외에는 방법이 없는지 궁금합니다.